### PR TITLE
Increased default buffer size (to 2048)

### DIFF
--- a/src/deduplicator/tailseq-dedup-perfect.c
+++ b/src/deduplicator/tailseq-dedup-perfect.c
@@ -37,7 +37,7 @@
 #include "../sigproc-flags.h"
 #include "../utils.h"
 
-#define DEFAULT_BUFFER_SIZE     1024
+#define DEFAULT_BUFFER_SIZE     2048
 #define MAX_TILENAME_LEN        63
 #define MAX_MODIFICATION_LEN    50
 #define MAX_UMI_LEN             50


### PR DESCRIPTION
Default buffer size caused tailseq-dedup-perfect to crash on some data (MiSeq reads PE 300+300, probably this is the case of long reads). However, I've not performed deep debugging to found exactly what data cause problem.