### PR TITLE
Resolved whole deprecated warning and obsolete errors

### DIFF
--- a/scripts/calculate-optimal-parameters.py
+++ b/scripts/calculate-optimal-parameters.py
@@ -40,7 +40,7 @@ def load_sig_dists(filename):
     elemsize, cycles, bins = struct.unpack('<III', inpf.read(12))
     assert elemsize == 4
 
-    counts = np.fromstring(inpf.read(), np.uint32).reshape((cycles, bins))
+    counts = np.frombuffer(inpf.read(), np.uint32).reshape((cycles, bins))
     spots_per_cycle = counts.sum(axis=1)
     return counts.astype(np.uint64), spots_per_cycle.astype(np.uint64)
 

--- a/scripts/measure-polya-lengths.py
+++ b/scripts/measure-polya-lengths.py
@@ -40,7 +40,7 @@ def load_sig_dists(filename):
     elemsize, cycles, bins = struct.unpack('<III', inpf.read(12))
     assert elemsize == 4
 
-    counts = np.fromstring(inpf.read(), np.uint32).reshape((cycles, bins))
+    counts = np.frombuffer(inpf.read(), np.uint32).reshape((cycles, bins))
     return counts.astype(np.uint64)
 
 def write_sig_dists(counts, filename):

--- a/scripts/stats-polya-len-dists.py
+++ b/scripts/stats-polya-len-dists.py
@@ -55,11 +55,10 @@ tableschema = refined_taginfo if snakemake.params.refined else taginfo
 columnname = 'unaligned_polyA' if snakemake.params.refined else 'polyA'
 columnno = tableschema['names'].index(columnname)
 
-pacounts = pd.DataFrame.from_items(
-    [(samplename,
-      get_polya_length_hist(lencallfile, snakemake.params.badflagmask,
-                            snakemake.params.maxpalength, columnno))
-     for samplename, lencallfile in inputfiles])
+pacounts = pd.DataFrame()
+for samplename, lencallfile in inputfiles:
+    pacounts[samplename] = get_polya_length_hist(
+        lencallfile, snakemake.params.badflagmask, snakemake.params.maxpalength, columnno)
 
 # trim all-zero rows at the end of the list
 effective_maximum_pa_len = np.where(pacounts.sum(axis=1) > 0)[0].max()

--- a/tailseeker/configurations.py
+++ b/tailseeker/configurations.py
@@ -37,7 +37,7 @@ class Configurations:
         self.paths = self.load_paths()
 
     def load_config(self, settings_file):
-        usersettings = yaml.load(settings_file)
+        usersettings = yaml.load(settings_file, Loader=yaml.FullLoader)
         if 'include' in usersettings:
             confdict = {}
 
@@ -106,7 +106,7 @@ class Configurations:
 
     def load_paths(self):
         pathconf = os.path.join(self.tailseeker_dir, self.PATH_CONF_FILE)
-        pathsettings = yaml.load(open(pathconf)) if os.path.exists(pathconf) else {}
+        pathsettings = yaml.load(open(pathconf), Loader=yaml.FullLoader) if os.path.exists(pathconf) else {}
         if 'paths' in self.confdata:
             pathsettings.update(self.confdata['paths'])
 
@@ -143,7 +143,7 @@ def scan_selectable_confs(tailseeker_dir):
     conffiles = glob.glob(os.path.join(tailseeker_dir, 'conf', '*.conf'))
 
     for conffilename in conffiles:
-        confdata = yaml.load(open(conffilename))
+        confdata = yaml.load(open(conffilename), Loader=yaml.FullLoader)
         if 'name' in confdata:
             yield (confdata['name'], conffilename)
 

--- a/tailseeker/powersnake.py
+++ b/tailseeker/powersnake.py
@@ -71,12 +71,7 @@ def load_snakemake_params():
 
     for varname, value in options.items():
         if not isinstance(value, int):
-            nl = Namedlist()
-            for k, v in value:
-                nl.append(v)
-                if k is not None:
-                    nl.add_name(k)
-            value = nl
+            value = Namedlist(fromdict=dict(value))
         setattr(builtins, varname, value)
 
 
@@ -92,7 +87,13 @@ def external_script(_command):
         if isinstance(callerlocal[var], int):
             packed[var] = callerlocal[var]
         else:
-            packed[var] = list(callerlocal[var].allitems())
+            numkeys = len(callerlocal[var].keys())
+            if numkeys == 0: # when there is no input name
+                packed[var] = [(str(i), v) for i, v in enumerate(callerlocal[var])]
+            else:
+                packed[var] = list(callerlocal[var].items())
+                assert numkeys == len(packed[var]),\
+                "A rule's input name must either all exist or not exist."
 
     with tempfile.NamedTemporaryFile(mode='wt') as tmpfile:
         json.dump(packed, tmpfile)


### PR DESCRIPTION
This version compatibility is based on `conda update all` at 28.01.2020  

Since yaml version 5.1, yaml load() requires its loader declaration.
[for more details](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation)

Since Numpy version 1.14, numpy.fromstring is deprecated using default sep=''.
[for more details](https://docs.scipy.org/doc/numpy/reference/generated/numpy.fromstring.html)

Since at least Snakemake 5.10.0, [add_name](https://github.com/snakemake/snakemake/blob/master/snakemake/io.py#L1200) and [allitems](https://github.com/snakemake/snakemake/blob/master/snakemake/io.py#L1250) is now indicated as internal use.
[for more details](https://github.com/snakemake/snakemake/blob/master/snakemake/io.py)
